### PR TITLE
Remove hard coded response type

### DIFF
--- a/src/oauth/index.js
+++ b/src/oauth/index.js
@@ -32,7 +32,7 @@ function initOauthToken(options: oAuthOptions) {
     query: {
       redirect_uri: redirect_uri,
       client_id: client_id,
-      response_type: "token"
+      response_type: oAuthOptions.response_type || "token"
     }
   });
 

--- a/src/oauth/index.js
+++ b/src/oauth/index.js
@@ -32,7 +32,7 @@ function initOauthToken(options: oAuthOptions) {
     query: {
       redirect_uri: redirect_uri,
       client_id: client_id,
-      response_type: oAuthOptions.response_type || "token"
+      response_type: options.response_type || "token"
     }
   });
 


### PR DESCRIPTION
This PR removes the hard-coded `response_type` var in order to make it possible for clients to chose their OAuth 2.0 Authorization flow.

The code flow may be useful when the client is either:
1. A server-side rendered app which doesn't share it's secrets with the clients which use it
2. An SPA which fetches the authorization code from the `redirect_uri`'s query string and sends it over to a server which then extracts the `authentication_token` from the code and does API calls on behalf of the authorized user