### PR TITLE
Add checksumfile method

### DIFF
--- a/src/utils/methods.js
+++ b/src/utils/methods.js
@@ -36,6 +36,7 @@ export const pCloudApiMethods: { [id: string]: pCloudApiMethod } = {
   changeshare: { auth: true, type: "write" },
   sharefolder: { auth: true, type: "write" },
   copyfile: { auth: true, type: "write" },
+  checksumfile: { auth: true, type: "read" },
   copyfolder: { auth: true, type: "write" },
   listpublinks: { auth: true, type: "read" },
   getfilepublink: { auth: true, type: "write" },


### PR DESCRIPTION
The checksumfile method is missing from `src/utils/methods.js`. Please let me know if e.g. you'd like the list to be in a particular order, or if an entry must be added somewhere else.