### PR TITLE
fixes #25

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "flow": "flow",
     "test": "yarn test-only",
     "test-only": "jest --coverage --colors",
-    "test:watch": "jest --colors --watch",
-    "precommit": "lint-staged"
+    "test:watch": "jest --colors --watch"
   },
   "engineStrict": true,
   "engines": {
@@ -95,11 +94,6 @@
     "testEnvironment": "node",
     "globals": {
       "ENV": "node"
-    }
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
     }
   },
   "lint-staged": {

--- a/src/api/ApiMethod.js
+++ b/src/api/ApiMethod.js
@@ -20,10 +20,10 @@ export default function ApiMethod(method: string, options: ApiMethodOptions = {}
     !isAuthMethod(method) || "auth" in params || "access_token" in params || "username" in params,
     "`auth` must be present for methods that require authentication."
   );
-
+  
   const requestUrl: string = url.format({
     protocol: apiProtocol,
-    host: locations[locationid] || apiServer,
+    host: params.hostname || apiServer,
     pathname: method,
     query: params,
   });

--- a/src/oauth/index.js
+++ b/src/oauth/index.js
@@ -103,9 +103,9 @@ function popup() {
   }
 }
 
-function getTokenFromCode(code: string, client_id: string, app_secret: string) {
+function getTokenFromCode(code: string, hostname: string, client_id: string, app_secret: string) {
   return ApiMethod("oauth2_token", {
-    params: { client_id: client_id, client_secret: app_secret, code: code },
+    params: { client_id: client_id, client_secret: app_secret, code: code, hostname: hostname },
   });
 }
 


### PR DESCRIPTION
I had to disable Husky since it prevented me from committing (there seems to be issues with test scripts and other stuff as well, for this repository).

The tiny changes is mainly in these two files:
```
src/api/ApiMethod.js 
src/oauth/index.js 
```

Your authorization endpoint returns a hostname, which seems to be required in **ApiRequest** (src/api/ApiMethod.js). The changes I've made, forwards the **hostname** value in order resolve the API request.

Finally, I tried to add a **hostname** prompt to ```https://github.com/pCloud/pcloud-sdk-js/blob/master/examples/node/token.js``` but that file does not to work at all, before any changes.