### PR TITLE
Debug download.html example.

### DIFF
--- a/examples/download.html
+++ b/examples/download.html
@@ -1,90 +1,158 @@
 <html>
-<head>
-  <title>pCloud SDK: Examples / Download</title>
+  <head>
+    <title>pCloud SDK: Examples / Download</title>
 
-  <style>
-    #gettoken {
-      position: fixed;
-      top: 20px;
-      right: 20px;
-    }
+    <style>
+      #ui {
+        position: fixed;
+        top: 20px;
+        right: 20px;
+      }
 
-    #files {
-      font-size: 13px;
-      font-family: arial;
-      line-height: 17px;
-    }
-  </style>
-</head>
-<body>
+      #files {
+        font-size: 13px;
+        font-family: arial;
+        line-height: 17px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="files"></div>
 
-  <div id="files"></div>
-  <button id="gettoken">Get Token</button>
+    <div id="ui">
+      <button id="gettoken">Get Token</button><br />
+      <button id="listfiles">List Files and Folders</button><br />
+      Folder levels to recurse: <input id="maxrecurse" type="text" length="2" size="2" value="2" /><br />
+      <span style="display: none" id="havetoken">Token loaded from local storage</span><br />
+    </div>
 
-  <script src="https://code.jquery.com/jquery-3.0.0.slim.min.js"></script>
-  <script type="text/javascript" src="/examples/pcloudsdk.js"></script>
-  <script>
-    'use strict';
-    var access_token = false;
-    var locationid = "";
-    var client = false;
+    <script src="https://code.jquery.com/jquery-3.0.0.slim.min.js"></script>
+    <script type="text/javascript" src="/examples/pcloudsdk.js"></script>
+    <script>
+      "use strict";
+      /*eslint-disable camelcase */
+      /*globals pCloudSdk */
+      var access_token = false;
+      var locationid = "";
+      var client = false;
 
-    function downloadfile(fileid) {
-      client.downloadfile(1780805874, {
-        onBegin: function() {
-          console.log('Upload started.');
-        },
-        onProgress: function(progress) {
-          console.log(progress);
-        },
-        onFinish: function(uploadData) {
-          console.log(uploadData);
+      // var allFolderAccessAppClientId = "3dunsTvYJsu"; // new_APP -- All folders acccess
+      var privateAppClientId = "p1WznE2dEPm"; // pCloudSampleApp -- Private folder access
+      var client_id = privateAppClientId;
+
+      var pcloudtoken = localStorage.getItem("pcloudToken");
+      var pcloudlocationid = localStorage.getItem("pcloudLocationId");
+
+      if (pcloudtoken && pcloudlocationid) {
+        $("#havetoken").show();
+        access_token = pcloudtoken;
+        locationid = pcloudlocationid;
+
+        client = pCloudSdk.createClient(access_token);
+      }
+
+      function downloadfile(fileid) {
+        client.downloadfile(fileid, {
+          onBegin: function() {
+            console.log("download started.");
+          },
+          onProgress: function(progress) {
+            console.log("download progress", progress);
+          },
+          onFinish: function(downloadData) {
+            console.log("download complete", downloadData);
+          },
+        });
+      }
+
+      function reportErr(err) {
+        console.error(err);
+      }
+
+      function listfiles(folderid, parentFolderName, depth) {
+        if (client) {
+          var place = $("#files");
+          var parentFolderLabel = parentFolderName || "Root folder";
+          var maxdepth = parseInt($("#maxrecurse").val(), 10) || 3;
+
+          depth = depth || 1;
+
+          client.listfolder(folderid || 0).then(function(metadata) {
+            if (!depth && !metadata.contents.length && client_id === privateAppClientId) {
+              place.html(
+                "No files found. Note that private apps only have access<br />" +
+                  "to files in <tt>Files/Applications/[Application Name]</tt> and below.<br />" +
+                  "Please add files to <tt>Files/Applications/pCloudExampleApp</tt>.<br />"
+              );
+            } else {
+              var folders = [];
+              var files = [];
+
+              metadata.contents.forEach(function(item) {
+                if (item.isfolder) {
+                  folders.push(item);
+                } else {
+                  files.push(item);
+                }
+              });
+
+              files.forEach(function(file) {
+                var linkText = `${file.name} (${parentFolderLabel}) [${depth}]`;
+
+                place.append(
+                  $("<div />")
+                    .append($("<span />").text(linkText))
+                    .append(" | ")
+                    .append(
+                      $('<a href="javascript:;">Download</a>').on("click", function(e) {
+                        console.log("downloading", file.fileid);
+                        downloadfile(file.fileid);
+                      })
+                    )
+                );
+              });
+
+              folders.forEach(function(folder) {
+                console.log("it's a folder", JSON.stringify(folder, null, "  "));
+                var newDepth = depth + 1;
+
+                place.append(
+                  $("<div />").append(
+                    $("<span />").text(`Folder: ${folder.name} (Parent: ${parentFolderLabel}) [${depth}]`)
+                  )
+                );
+
+                if (depth < maxdepth) {
+                  listfiles(folder.folderid, folder.name, newDepth);
+                }
+              });
+            }
+          }, reportErr);
         }
-      });
-    }
+      }
 
-    function listfiles() {
-      var place = $('#files');
-      client.listfolder(0).then(function(metadata) {
-        metadata.contents.forEach(function(item, n) {
-          if (!item.isfolder) {
-            place.append(
-              $('<div />')
-                .append($('<span />').text(item.name))
-                .append(' | ')
-                .append(
-                  $('<a href="javascript:;">Download</a>')
-                    .on('click', function(e) {
-                      console.log('downloading', item.fileid);
-                      downloadfile(item.fileid);
-                    })
-                )
-            );
-          }
+      $("#gettoken").click(function(e) {
+        pCloudSdk.oauth.initOauthToken({
+          client_id: client_id,
+          redirect_uri: "http://127.0.0.1:8080/oauth.html",
+          receiveToken: function(token, id) {
+            console.log(token);
+            access_token = token;
+            locationid = id || "1";
+
+            localStorage.setItem("pcloudToken", access_token);
+            localStorage.setItem("pcloudLocationId", locationid);
+            $("#havetoken").show();
+
+            client = pCloudSdk.createClient(access_token);
+          },
         });
       });
-    }
 
-
-    function el(id) {
-      return document.getElementById(id);
-    }
-
-    el('gettoken').addEventListener('click', function(e) {
-      pCloudSdk.oauth.initOauthToken({
-        client_id: 'p1WznE2dEPm',
-        redirect_uri: 'http://127.0.0.1:8080/oauth.html',
-        receiveToken: function(token, id) {
-          console.log(token);
-          access_token = token;
-          locationid = id || 1;
-          client = pCloudSdk.createClient(token);
-
-          listfiles();
-        }
+      $("#listfiles").click(function() {
+        $("#files").html("Root folder");
+        listfiles(0);
       });
-    }, false);
-
-  </script>
-</body>
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
This PR makes `download.html` [nearly] functional. The previous version did not work.

I've made a few fixes and changes, including adding several convenience features.

1. Fixed typos in `downloadfile` function
    * The `fileid` was ignored; value had been hard-coded, which wouldn't work.
    * `console.log`s referenced "uploads"; now says download.
2. Auth token is now saved in [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) so that you don't have to get a token each time.
3. `access_token` was assigned but unused; it's now trivially used.
4. `locationid` was assigned but unused. It's saved to `localStorage` now, but is essentially unused.
    * I can't find its use in [`createClient`](https://github.com/pCloud/pcloud-sdk-js/blob/9a3a27dc5765bc1b95e402e2e564012227f84fda/docs/createclient.md), eg.
5. `listFiles` is now recursive through folders.
6. `lifeFiles` reads a `maxdepth` from the ui to limit the folder depth used. 
    * Default is `2` to include `Demo Audio 2.mp3` if using a `client_id` with all folder access.
7. Message displayed explaining "private" apps if no files are found for the pCloudSampleApp `client_id`.
8. Double-quotes as requested by [.prettierrc](https://github.com/pCloud/pcloud-sdk-js/blob/a4e16c05736c3223f4bd126900b1949656c81066/.prettierrc#L6).

I realize this is slightly more complicated than a simplest case, but is the minimum I think you could give to demonstrate something approaching real-world usage. At just under 150 lines with html, it's not horrible. It is both folder & file listing plus download.

---

### `client_id`s and private vs. all folder access

I noticed that there were two `client_id` values being used throughout the `example` folder:

1. new_APP, `client_id` of `"3dunsTvYJsu"`, **ALL FOLDERS** access
2. pCloudSampleApp, `client_id` of `"p1WznE2dEPm"`, private access only

I included both in the code here, though the pCloundSampleApp `client_id` is hooked up by default. That does mean a user needs to put files in its app folder, which is why I added the message in case the app-specific folder is empty, as mentioned above.

---

### Strange server behavior

There are a few other things I'd clean up in a perfect world. I'd remove parent-scoped variables and change variable names to camelCase, for instance. But this seems to work fairly well, except...

The download doesn't seem to work! There's a CORS error, which means pCloud would need to change settings on the API side for this to work from a browser using the example code, even fixed.

It'll work from node, of course, or something else that isn't worried about CORS, but not from a browser on a non-pCloud domain.

> ```
> download.html:1 Access to XMLHttpRequest at 
> 'https://vc828.pcloud.com/[value removed]/Demo%20Audio%202.mp3' 
> from origin 'http://127.0.0.1:8080' has been blocked by CORS policy: 
> No 'Access-Control-Allow-Origin' header is present on the requested resource.
> ```

I'll open an issue for that and reference it here. EDIT: Looks like [it's been open a while](https://github.com/pCloud/pcloud-sdk-js/issues/4), and the answer is that [`getfilelink` isn't supposed to work with CORS](https://docs.pcloud.com/methods/streaming/getfilelink.html). :sigh:

<img width="495" alt="This method can't be used from web applications. Referrer is restricted to pcloud.com." src="https://user-images.githubusercontent.com/5659878/188544185-f8581677-4458-4c45-82c7-0f65f8c16935.png">

If true, we should probably remove `download.html`, right?

I've also noticed I have to sign-in twice in the OAuth interface to get a token with the examples. That's strange, though it doesn't prevent the app from eventually functioning.

Thank you!